### PR TITLE
Twitter -> X relabelling and addition of GitHub in footer socials

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -11,7 +11,7 @@ ignoreFiles: [ "\\.qmd$", "\\.py$" ]
 params:
   gtag: G-SSDJH3F7EZ
   description: A site where quants write about mathematics, engineering and finance.
-  site_twitter_handler: 'DrAdrian'
+  site_x_handler: 'DrAdrian'
   images:
     - feature.png
 

--- a/config.yaml
+++ b/config.yaml
@@ -12,6 +12,7 @@ params:
   gtag: G-SSDJH3F7EZ
   description: A site where quants write about mathematics, engineering and finance.
   site_x_handler: 'DrAdrian'
+  site_github_handler: 'robolyst/osquant'
   images:
     - feature.png
 

--- a/content/authors/adrian-letchford/_index.md
+++ b/content/authors/adrian-letchford/_index.md
@@ -6,7 +6,7 @@ full_name: Dr. Adrian Letchford
 last_first: Letchford, Adrian
 job_title: Quantitative Developer
 
-twitter: dradrian
+x: dradrian
 github: robolyst
 linkedin: adrianletchford
 ---

--- a/content/authors/daniel-nunns/_index.md
+++ b/content/authors/daniel-nunns/_index.md
@@ -6,7 +6,7 @@ full_name: Daniel Nunns
 last_first: Nunns, Daniel
 job_title: Quantitative Trader
 
-twitter: dbnunns
+x: dbnunns
 github: nunnsy
 linkedin: daniel-nunns
 ---

--- a/themes/osquant/assets/sass/main.scss
+++ b/themes/osquant/assets/sass/main.scss
@@ -1139,7 +1139,7 @@ Sidebars
                 font-style: italic;
             }
 
-            a.twitter-follow {
+            a.x-follow, a.linkedin-follow {
                 background-color: #4A99E9;
                 border-radius: 5px;
                 text-align: center;

--- a/themes/osquant/layouts/_default/author.html
+++ b/themes/osquant/layouts/_default/author.html
@@ -12,7 +12,7 @@
                     <h1 class='title'>{{ .Title | title }}</h1>
                     {{ .Content }}
                     <div class="social-links">
-                        {{ with .Params.twitter }}<a href="https://twitter.com/{{ . }}"><img src="/img/x-grey.svg" /></a>{{ end }}
+                        {{ with .Params.x }}<a href="https://x.com/{{ . }}"><img src="/img/x-grey.svg" /></a>{{ end }}
                         {{ with .Params.github }}<a href="https://github.com/{{ . }}"><img src="/img/github-grey.svg" /></a>{{ end }}
                         {{ with .Params.linkedin }}<a href="https://www.linkedin.com/in/{{ . }}"><img src="/img/linkedin-grey.svg" /></a>{{ end }}
                         {{ with .Params.instagram }}<a href="https://instagram.com/{{ . }}"><img src="/img/instagram-grey.svg" /></a>{{ end }}

--- a/themes/osquant/layouts/partials/back-matter.html
+++ b/themes/osquant/layouts/partials/back-matter.html
@@ -17,7 +17,7 @@
     {{ end }}
 
     <h2>Corrections</h2>
-    <p>If you see any mistakes or room for improvement, please reach out to me on Twitter <a href="http://www.twitter.com/dradrian">@DrAdrian</a>.</p>
+    <p>If you see any mistakes or room for improvement, please reach out to me on X <a href="http://www.x.com/dradrian">@DrAdrian</a>.</p>
 
     <h2>Citation</h2>
     <p>Please cite this work as:</p>

--- a/themes/osquant/layouts/partials/footer.html
+++ b/themes/osquant/layouts/partials/footer.html
@@ -8,7 +8,7 @@
                 <div class="logo">Open Source Quant</div>
                 <div class="slogan">Clear. Rigorous. Beautiful.</div>
                 <div class="socials">
-                    {{ with .Site.Params.site_twitter_handler }}<a href="https://twitter.com/{{ . }}"><img src="/img/x-grey.svg" /></a>{{ end }}
+                    {{ with .Site.Params.site_x_handler }}<a href="https://x.com/{{ . }}"><img src="/img/x-grey.svg" /></a>{{ end }}
                 </div>
             </div>
             <div class="right">

--- a/themes/osquant/layouts/partials/footer.html
+++ b/themes/osquant/layouts/partials/footer.html
@@ -9,6 +9,7 @@
                 <div class="slogan">Clear. Rigorous. Beautiful.</div>
                 <div class="socials">
                     {{ with .Site.Params.site_x_handler }}<a href="https://x.com/{{ . }}"><img src="/img/x-grey.svg" /></a>{{ end }}
+                    {{ with .Site.Params.site_github_handler }}<a href="https://github.com/{{ . }}"><img src="/img/github-grey.svg" /></a>{{ end }}
                 </div>
             </div>
             <div class="right">

--- a/themes/osquant/layouts/partials/sidebar_author_box.html
+++ b/themes/osquant/layouts/partials/sidebar_author_box.html
@@ -9,14 +9,14 @@
             <name><a href="{{ .Permalink }}">{{ .Params.full_name }}</a></name>
             <job>{{ .Params.job_title }}</job>
 
-            <!-- If the author has a Twitter handle, display the call to action -->
-            {{ if isset .Params "twitter" }}
-                <a class="twitter-follow" href="https://twitter.com/{{ .Params.twitter }}" class="twitter-follow">Follow on X</a>
+            <!-- If the author has an X handle, display the call to action -->
+            {{ if isset .Params "x" }}
+                <a class="x-follow" href="https://x.com/{{ .Params.x }}" class="x-follow">Follow on X</a>
             {{ end }}
 
             <!-- If the author has a LinkedIn handle, display the call to action -->
             {{ if isset .Params "linkedin" }}
-                <a class="twitter-follow" href="https://www.linkedin.com/in/{{ .Params.linkedin }}" class="twitter-follow">Connect on LinkedIn</a>
+                <a class="linkedin-follow" href="https://www.linkedin.com/in/{{ .Params.linkedin }}" class="linkedin-follow">Connect on LinkedIn</a>
             {{ end }}
 
         {{ end }}

--- a/themes/osquant/layouts/partials/sidebar_share_box.html
+++ b/themes/osquant/layouts/partials/sidebar_share_box.html
@@ -3,7 +3,7 @@
 <div class="box">
     <div class="title">Share this article</div>
     <div class="share-icons">
-        <a href="https://twitter.com/share?url={{ .Permalink | urlquery }}&text={{ .Title | urlquery }}&via={{ .Site.Params.site_twitter_handler }}"><img src="/img/x-blue.svg" /></a>
+        <a href="https://x.com/share?url={{ .Permalink | urlquery }}&text={{ .Title | urlquery }}&via={{ .Site.Params.site_x_handler }}"><img src="/img/x-blue.svg" /></a>
         <a href="http://www.facebook.com/sharer.php?u={{ .Permalink | urlquery }}"><img src="/img/facebook-blue.svg" /></a>
         <a href="https://getpocket.com/save?url={{ .Permalink | urlquery }}&title={{ .Title | urlquery }}"><img src="/img/pocket-blue.svg" /></a>
         <a href="https://www.reddit.com/submit?url={{ .Permalink | urlquery }}&title={{ .Title | urlquery }}"><img src="/img/reddit-blue.svg" /></a>

--- a/themes/osquant/layouts/partials/twitter-call-to-action.html
+++ b/themes/osquant/layouts/partials/twitter-call-to-action.html
@@ -3,16 +3,16 @@
     <!-- Turn the author's text name into their page object -->
     {{ with $.Site.GetPage (printf "/%s/%s" "authors" (. | urlize)) }}
 
-        <!-- If the author has a Twitter handle, display the call to action -->
-        {{ if isset .Params "twitter" }}
+        <!-- If the author has an X handle, display the call to action -->
+        {{ if isset .Params "x" }}
 
             <div class="container">
                 <div class="callout">
                     <span>
                         <span class="title">Like what you see?</span>
-                        <span class="subtext">Follow {{ .Params.first_name }} on Twitter to be notified of new content.</span>
+                        <span class="subtext">Follow {{ .Params.first_name }} on X to be notified of new content.</span>
                     </span>
-                    <a href="https://twitter.com/{{ .Params.twitter }}" class="twitter-follow">Follow</a>
+                    <a href="https://x.com/{{ .Params.x }}" class="x-follow">Follow</a>
                 </div>
             </div>
 

--- a/themes/osquant/layouts/partials/twitter_card.html
+++ b/themes/osquant/layouts/partials/twitter_card.html
@@ -1,9 +1,9 @@
 <meta name="twitter:card" content="summary_large_image" /> 
-<meta name="twitter:site" content="@{{.Site.Params.site_twitter_handler}}" /> 
+<meta name="twitter:site" content="@{{.Site.Params.site_x_handler}}" /> 
 
 {{ range .Params.authors }}
     {{ with $.Site.GetPage (printf "/%s/%s" "authors" (. | urlize)) }}
-        <meta name=”twitter:creator content="@{{ .Params.twitter }}" /> 
+        <meta name=”twitter:creator content="@{{ .Params.x }}" /> 
     {{ end }}
 {{ end }}
 


### PR DESCRIPTION
Addresses https://github.com/robolyst/osquant/issues/38 and converts some twitter.com links to x.com (maybe Elon might like us more to let us display images).

<img width="785" height="169" alt="image" src="https://github.com/user-attachments/assets/c0e67fc3-ca29-4e1f-8893-beef26e44af7" />
